### PR TITLE
fix(web): reset code styles in terminal blocks (#21)

### DIFF
--- a/web/src/style.css
+++ b/web/src/style.css
@@ -277,6 +277,13 @@ html.js .features__grid .reveal:nth-child(6) { transition-delay: 400ms; }
   color: var(--color-subtle);
 }
 
+.terminal__body code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+}
+
 .terminal__prompt {
   color: var(--color-pop);
   user-select: none;


### PR DESCRIPTION
## Summary
- Override global `code` element styles (background, padding, border-radius) inside `.terminal__body` to prevent visual conflict with the dark terminal theme

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)