### PR TITLE
feat: add cargo-generate support + agent-friendly errors (#26)

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,0 +1,8 @@
+[template]
+cargo_generate_version = ">=0.18.0"
+description = "Opinionated Rust CLI template with AI agent support, NPX distribution, and CI/CD"
+
+[placeholders.github-org]
+type = "string"
+prompt = "GitHub organization or username"
+default = "rararulab"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,11 @@
 //! Application-level error types.
+//!
+//! ## Agent-friendly error output
+//!
+//! When reporting errors to stdout as JSON, include a `suggestion` field:
+//! ```json
+//! {"ok": false, "error": "service not found", "suggestion": "run 'my-cli list' to see available services"}
+//! ```
 
 use snafu::Snafu;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ async fn main() {
         eprintln!("Error: {e}");
         println!(
             "{}",
-            serde_json::json!({"ok": false, "error": e.to_string()})
+            serde_json::json!({"ok": false, "error": e.to_string(), "suggestion": "check --help for usage"})
         );
         std::process::exit(1);
     }


### PR DESCRIPTION
## Summary

- Add `cargo-generate.toml` so new projects can scaffold via `cargo generate` instead of manual find-replace
- Add `suggestion` field to JSON error output (per rararulab agent-friendly CLI guide)
- Add agent-friendly error pattern docs to `src/error.rs`

## Usage

```bash
cargo generate --git https://github.com/rararulab/cli-template --name my-cli
```

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)