### PR TITLE
chore(cli): align template with org agent-friendly standards (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,16 @@ cargo install --path .
 
 ### From template
 
-1. `cargo generate rararulab/cli-template`
-2. Find and replace `{{project-name}}` with your project name
-3. Update `CLAUDE.md` with your project description
-4. Run `just setup-hooks` to install pre-commit hooks
-5. Start building!
+```bash
+cargo generate rararulab/cli-template
+```
+
+You'll be prompted for project name and GitHub org. Then:
+
+1. `cd <your-project>`
+2. Update `CLAUDE.md` with your project description
+3. Run `just setup-hooks` to install pre-commit hooks
+4. Start building!
 
 ## Development
 
@@ -106,19 +111,14 @@ Override via CLI:
 {{project-name}} config set agent.idle_timeout_secs 60
 ```
 
-## Claude Code Integration
+## Agent-Friendly CLI Design
 
-Built-in `/dev` skill for autonomous development pipeline:
+This template follows [rararulab agent-friendly CLI standards](https://github.com/rararulab/.github/blob/main/docs/agent-friendly-cli.md):
 
-```
-/dev <requirement>        # Full cycle: design → implement → review → ship
-/dev --quick <requirement> # Skip design & review for trivial changes
-```
-
-Includes:
-- `CLAUDE.md` with project conventions and code style guides
-- `/dev` skill with subagent prompts for implementation, code review, and design review
-- Development guides: workflow, commit style, Rust style, code comments, anti-patterns
+- **JSON stdout, logs stderr** — all commands output structured JSON on stdout
+- **Fail fast with suggestions** — errors include `suggestion` field for self-correction
+- **Non-interactive** — every parameter passable via flags
+- **Example-driven help** — each subcommand shows runnable examples in `--help`
 
 ## Project Structure
 
@@ -137,14 +137,6 @@ src/
 ├── app_config.rs   # TOML config with OnceLock
 ├── paths.rs        # Centralized data directory paths
 └── http.rs         # Shared reqwest HTTP clients
-
-.claude/
-└── skills/
-    └── dev/        # /dev autonomous development pipeline
-        ├── SKILL.md
-        └── references/
-            ├── templates.md
-            └── subagent-prompts.md
 
 npm/                # npx install package (optionalDependencies pattern)
 ├── package.json    # Main package with platform optionalDependencies

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,9 +11,18 @@ pub struct Cli {
 }
 
 /// Available subcommands.
+///
+/// Commands follow the agent-friendly CLI pattern:
+/// - JSON on stdout, human text on stderr
+/// - Every error includes a `suggestion` field
+/// - All parameters passable via flags (non-interactive)
 #[derive(Subcommand)]
 pub enum Command {
     /// Say hello (example command — replace with your own)
+    #[command(after_help = "\
+EXAMPLES:
+    {{project-name}} hello
+    {{project-name}} hello Alice")]
     Hello {
         /// Name to greet
         #[arg(default_value = "world")]
@@ -21,12 +30,21 @@ pub enum Command {
     },
 
     /// Manage config values
+    #[command(after_help = "\
+EXAMPLES:
+    {{project-name}} config list
+    {{project-name}} config get agent.backend
+    {{project-name}} config set agent.backend gemini")]
     Config {
         #[command(subcommand)]
         action: ConfigAction,
     },
 
     /// Run a prompt through the configured agent backend
+    #[command(after_help = "\
+EXAMPLES:
+    {{project-name}} agent \"explain this codebase\"
+    {{project-name}} agent --backend codex \"refactor main.rs\"")]
     Agent {
         /// The prompt to send to the agent
         prompt: String,
@@ -40,6 +58,11 @@ pub enum Command {
 #[derive(Subcommand)]
 pub enum ConfigAction {
     /// Set a config value
+    #[command(after_help = "\
+EXAMPLES:
+    {{project-name}} config set example.setting myvalue
+    {{project-name}} config set agent.backend gemini
+    {{project-name}} config set agent.idle_timeout_secs 60")]
     Set {
         /// Config key (e.g. example.setting)
         key:   String,
@@ -47,10 +70,17 @@ pub enum ConfigAction {
         value: String,
     },
     /// Get a config value
+    #[command(after_help = "\
+EXAMPLES:
+    {{project-name}} config get example.setting
+    {{project-name}} config get agent.backend")]
     Get {
         /// Config key to look up
         key: String,
     },
     /// List all config values
+    #[command(after_help = "\
+EXAMPLES:
+    {{project-name}} config list")]
     List,
 }


### PR DESCRIPTION
## Summary
- Update README: proper `cargo generate` instructions, remove deleted `/dev` skill section, add agent-friendly CLI design section
- Add `after_help` examples to every subcommand for agent discoverability
- Add doc comment on `Command` enum noting agent-friendly conventions

Closes #28

## Audit Status

| Principle | Before | After |
|-----------|--------|-------|
| Example-Driven Help | ❌ | ✅ |
| README accuracy | ❌ | ✅ |
| Other 8 principles | ✅/N/A | ✅/N/A |

🤖 Generated with [Claude Code](https://claude.com/claude-code)